### PR TITLE
Reorder  UseAuthorization after UseStatusCodePagesWithRedirects

### DIFF
--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddSingleton<RequestContext>();
 var app = builder.Build();
 
 app.UseStatusCodePagesWithRedirects("/error/{0}");
+app.UseAuthorization();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
WebApplication's automatic UseAuthorization() insertion happens before the user-configured UseStatusCodePagesWithRedirecte(). By adding UseAuthorization() explicitly, we can ensure UseStatusCodePagesWithRedirecte() "sees" unauthorized requests.

https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/middleware?view=aspnetcore-8.0

This should address this issue described in https://github.com/dotnet/aspnetcore/issues/49515.